### PR TITLE
(test) - Add an option to specify host header in a request - refs #5579

### DIFF
--- a/src/Blast/Bundle/TestsBundle/Api/BlastApiTestCase.php
+++ b/src/Blast/Bundle/TestsBundle/Api/BlastApiTestCase.php
@@ -24,6 +24,7 @@ class BlastApiTestCase extends TestCase
     protected $result;
     protected $show_results;
     protected $show_curl;
+    protected $vhost;
 
     /********** HTTPResult **********/
     protected $data;
@@ -38,7 +39,7 @@ class BlastApiTestCase extends TestCase
         $optidx = array_search('CONF', $argv);
 
         if (!$optidx || $argc < $optidx + 3) {
-            die("Usage: phpunit tests CONF 'http://my.url.srv' username password\n");
+            die("Usage: phpunit tests CONF 'http://my.url.srv' username password [vhost]\n");
         }
 
         /* @todo check if base is a valid url */
@@ -46,6 +47,7 @@ class BlastApiTestCase extends TestCase
         $this->base = $argv[$optidx + 1];
         $this->identifier = $argv[$optidx + 2];
         $this->secret = $argv[$optidx + 3];
+        $this->vhost = $argv[$optidx + 4];
 
         if (array_search('SHOW_RESULT', $argv)) {
             $this->show_results = true;
@@ -134,6 +136,10 @@ class BlastApiTestCase extends TestCase
         }
 
         $headers = $format == 'json' ? ['Content-Type: application/json'] : [];
+        if ($this->vhost) {
+            $headers[] = 'Host: ' . $this->vhost;
+        }
+        
         if ($this->token) {
             $headers[] = 'Authorization: Bearer ' . $this->token;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Fixed tickets | fixes #5579
| License       | LGPL


Add an option in the command line to pass IP adress to Curl with a host name.
ex:
<pre>vendor/bin/phpunit tests/Api/Test.php CONF http://127.0.0.1/test.php toto 123456 toto.test</pre>


